### PR TITLE
Update links to Serverless docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,9 +342,9 @@ resources:
 
 The following serverless commands are currently implemented for the OpenWhisk provider.
 
-- `deploy` - [Deploy functions, triggers and rules for service](https://serverless.com/framework/docs/providers/aws/cli-reference/deploy/).
-- `invoke`- [Invoke deployed serverless function and show result](https://serverless.com/framework/docs/providers/aws/cli-reference/invoke/).
-- `invokeLocal`- [Invoke serverless functions locally and show result](https://serverless.com/framework/docs/providers/aws/cli-reference/invoke#invoke-local).
-- `remove` - [Remove functions, triggers and rules for service](https://serverless.com/framework/docs/providers/aws/cli-reference/remove/).
-- `logs` - [Display activation logs for deployed function](https://serverless.com/framework/docs/providers/aws/cli-reference/logs/). 
-- `info` - [Display details on deployed functions, triggers and rules](https://serverless.com/framework/docs/providers/aws/cli-reference/info/).
+- `deploy` - [Deploy functions, triggers and rules for service](https://serverless.com/framework/docs/providers/openwhisk/cli-reference/deploy/).
+- `invoke`- [Invoke deployed serverless function and show result](https://serverless.com/framework/docs/providers/openwhisk/cli-reference/invoke/).
+- `invokeLocal`- [Invoke serverless functions locally and show result](https://serverless.com/framework/docs/providers/openwhisk/cli-reference/invoke#invoke-local).
+- `remove` - [Remove functions, triggers and rules for service](https://serverless.com/framework/docs/providers/openwhisk/cli-reference/remove/).
+- `logs` - [Display activation logs for deployed function](https://serverless.com/framework/docs/providers/openwhisk/cli-reference/logs/). 
+- `info` - [Display details on deployed functions, triggers and rules](https://serverless.com/framework/docs/providers/openwhisk/cli-reference/info/).


### PR DESCRIPTION
So that they point to the `openwhisk` docs rather than the `aws` docs.