### PR TITLE
Add support for specifying blackbox Docker image

### DIFF
--- a/compile/functions/index.js
+++ b/compile/functions/index.js
@@ -84,6 +84,10 @@ class OpenWhiskCompileFunctions {
     return functionObject.runtime || this.serverless.service.provider.runtime || 'nodejs:default';
   }
 
+  calculateImage(functionObject) {
+    return functionObject.image || this.serverless.service.provider.image || undefined;
+  }
+
   calculateOverwrite(functionObject) {
     let Overwrite = true;
 
@@ -135,7 +139,8 @@ class OpenWhiskCompileFunctions {
   compileFunctionExec(functionObject) {
     const main = this.calculateFunctionMain(functionObject);
     const kind = this.calculateRuntime(functionObject);
-    return this.generateActionPackage(functionObject).then(code => ({ main, kind, code }));
+    const image = this.calculateImage(functionObject);
+    return this.generateActionPackage(functionObject).then(code => image ? { main, kind, code, image } : { main, kind, code });
   }
 
   // This method takes the function handler definition, parsed from the user's YAML file,

--- a/compile/functions/tests/index.js
+++ b/compile/functions/tests/index.js
@@ -181,6 +181,7 @@ describe('OpenWhiskCompileFunctions', () => {
       const mem = 100;
       const timeout = 10;
       const runtime = 'runtime';
+      const image = 'image';
       const overwrite = false;
       const parameters = {
         foo: 'bar',
@@ -194,7 +195,7 @@ describe('OpenWhiskCompileFunctions', () => {
         namespace: 'testing_namespace',
         overwrite: false,
         action: {
-          exec: { main: 'some_function', kind: runtime, code: new Buffer(fileContents) },
+          exec: { main: 'some_function', kind: runtime, image: image, code: new Buffer(fileContents) },
           limits: { timeout: timeout * 1000, memory: mem },
           parameters: [
             { key: 'foo', value: 'bar' },
@@ -217,6 +218,7 @@ describe('OpenWhiskCompileFunctions', () => {
           memory: mem,
           overwrite,
           runtime,
+          image,
           handler,
           parameters,
           annotations
@@ -231,6 +233,7 @@ describe('OpenWhiskCompileFunctions', () => {
       const mem = 100;
       const timeout = 10;
       const runtime = 'runtime';
+      const image = 'image';
       const overwrite = false;
 
       const newFunction = {
@@ -238,7 +241,7 @@ describe('OpenWhiskCompileFunctions', () => {
         namespace: 'testing_namespace',
         overwrite: false,
         action: {
-          exec: { main: 'some_function', kind: runtime, code: new Buffer(fileContents) },
+          exec: { main: 'some_function', kind: runtime, image: image, code: new Buffer(fileContents) },
           limits: { timeout: timeout * 1000, memory: mem },
           parameters: [],
           annotations: []
@@ -250,7 +253,7 @@ describe('OpenWhiskCompileFunctions', () => {
       });
 
       openwhiskCompileFunctions.serverless.service.provider = {
-        memory: mem, timeout, overwrite, namespace: 'namespace', runtime,
+        memory: mem, timeout, overwrite, namespace: 'namespace', runtime, image,
       };
       return expect(
         openwhiskCompileFunctions.compileFunction('functionName', {


### PR DESCRIPTION
I made this patch as simple as possible so I could set the Docker image used for `runtime: blackbox` deployments. Didn't add any docs, just made it possible to pass the image parameter to OpenWhisk. This is related to #23.

This is more useful (and easier to use) when https://github.com/openwhisk/openwhisk/issues/1927 is resolved, but currently it's possible to use a custom image with a hard-coded JavaScript function name to get around it for some use cases.