### PR TITLE
Add loading javascript obj file as path

### DIFF
--- a/invokeLocal/index.js
+++ b/invokeLocal/index.js
@@ -50,7 +50,11 @@ class OpenWhiskInvokeLocal {
       const params = this.options.functionObj.parameters || {};
       let data = {};
       try {
-        data = JSON.parse(this.options.data);
+        if(typeof this.options.data === 'object') {
+          data = this.options.data;
+        } else {
+          data = JSON.parse(this.options.data);
+        }
       } catch (exception) {
         // do nothing if it's a simple string or object already
       }

--- a/invokeLocal/tests/index.js
+++ b/invokeLocal/tests/index.js
@@ -17,15 +17,15 @@ const getTmpFilePath = (fileName) => path.join(getTmpDirPath(), fileName);
 describe('OpenWhiskInvokeLocal', () => {
   const CLI = function () { this.consoleLog = function () {};};
   const serverless = {
-    config: () => {}, 
+    config: () => {},
     utils: {},
-    pluginManager: { getPlugins: () => []}, 
-    classes: {Error, CLI}, 
+    pluginManager: { getPlugins: () => []},
+    classes: {Error, CLI},
     service: {
       environment: {},
-      getFunction: () => {}, 
-      provider: {}, 
-      resources: {}, 
+      getFunction: () => {},
+      provider: {},
+      resources: {},
       getAllFunctions: () => []
     }
   };
@@ -146,6 +146,23 @@ describe('OpenWhiskInvokeLocal', () => {
       };
       serverless.utils.fileExistsSync = () => true;
       serverless.utils.readFileSync = path => JSON.stringify(data);
+      const dataFile = path.join(serverless.config.servicePath, 'data.json');
+      openwhiskInvokeLocal.options.path = dataFile;
+
+      return openwhiskInvokeLocal.validate().then(() => {
+        expect(openwhiskInvokeLocal.options.data).to.deep.equal(data);
+      });
+    });
+
+    it('it should accept file path containing javascript object', () => {
+      serverless.config.servicePath = getTmpDirPath();
+      const data = {
+        event: {
+          testProp: 'testValue',
+        },
+      };
+      serverless.utils.fileExistsSync = () => true;
+      serverless.utils.readFileSync = path => data;
       const dataFile = path.join(serverless.config.servicePath, 'data.json');
       openwhiskInvokeLocal.options.path = dataFile;
 
@@ -353,7 +370,7 @@ describe('OpenWhiskInvokeLocal', () => {
       return openwhiskInvokeLocal.invokeLocalNodeJs('fixture/handlerWithError', 'withRejectedPromise').then(() => {
         expect(process.exitCode).to.be.equal(1);
         expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('errorMessage');
-      }) 
+      })
     });
   });
 });


### PR DESCRIPTION
When doing a local invoke and passing the 'path' parameter, a json string can be loaded from file. This will add the possibility to directly load a javascript object from file (for example: output copied from another action ran locally).