### PR TITLE
Optimize path extraction of action handlers

### DIFF
--- a/compile/functions/runtimes/base.js
+++ b/compile/functions/runtimes/base.js
@@ -51,7 +51,11 @@ class BaseRuntime {
   }
 
   convertHandlerToPath(functionHandler) {
-    return functionHandler.replace(/\..*$/, this.extension)
+    const lastDot = functionHandler.lastIndexOf('.');
+    if (lastDot === -1) {
+      return functionHandler;
+    }
+    return functionHandler.substring(0, lastDot) + this.extension;
   }
 
   generateActionPackage(functionObject) {

--- a/compile/functions/tests/index.js
+++ b/compile/functions/tests/index.js
@@ -7,6 +7,29 @@ require('chai').use(chaiAsPromised);
 
 const sinon = require('sinon');
 const OpenWhiskCompileFunctions = require('../index');
+const BaseRuntime = require('../runtimes/base.js');
+
+describe('BaseRuntime', () => {
+  describe('#convertHandlerToPath', () => {
+    const base = new BaseRuntime();
+    base.extension = '.js';
+
+    it('should extract the path for a given file handler', () => {
+      const result = base.convertHandlerToPath('index.main');
+      expect(result).to.equal('index.js');
+    });
+
+    it('should return the input for a given file handler without exported function', () => {
+      const result = base.convertHandlerToPath('index');
+      expect(result).to.equal('index');
+    });
+
+    it('should extract the path for a given path handler', () => {
+      const result = base.convertHandlerToPath('myFunction@0.1.0/index.main');
+      expect(result).to.equal('myFunction@0.1.0/index.js');
+    });
+  });
+});
 
 describe('OpenWhiskCompileFunctions', () => {
   let serverless;


### PR DESCRIPTION
* The name of the exported function is now correctly replaced by the extension in the `convertHandlerToPath` method. The split is now performed at the last dot instead of the first.
* Unit tests added.
* Fixes #65.