### PR TITLE
Activate compression for action package

### DIFF
--- a/compile/functions/runtimes/base.js
+++ b/compile/functions/runtimes/base.js
@@ -67,8 +67,10 @@ class BaseRuntime {
 
     return this.getArtifactZip(functionObject)
       .then(zip => this.processActionPackage(handlerFile, zip))
-      .then(zip => zip.generateAsync({type: 'nodebuffer'}))
-      .then(buf => buf.toString('base64'))
+      .then(zip => zip.generateAsync(
+        { type: 'nodebuffer', compression: 'DEFLATE', compressionOptions: { level: 9 } }
+      ))
+      .then(buf => buf.toString('base64'));
   }
 
   getArtifactZip(functionObject) {


### PR DESCRIPTION
* Activated `DEFLATE` compression algorithm in jszip for the generation of the action package.
* Fixes #67.