### PR TITLE
Update packaging to support relative paths

### DIFF
--- a/compile/functions/runtimes/tests/all.js
+++ b/compile/functions/runtimes/tests/all.js
@@ -1,6 +1,7 @@
 'use strict';
 
 require('./index')
+require('./base')
 require('./node')
 require('./docker')
 require('./python')

--- a/compile/functions/runtimes/tests/base.js
+++ b/compile/functions/runtimes/tests/base.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const expect = require('chai').expect;
+
+const BaseRuntime = require('../base');
+
+describe('Base', () => {
+  const base = new BaseRuntime();
+  base.extension = '.js';
+
+  describe('#calculateFunctionMain()', () => {
+    it('should extract the main function for a given file handler', () => {
+      const functionObject = { handler: 'index.main' };
+      const result = base.calculateFunctionMain(functionObject);
+      expect(result).to.equal('main');
+    });
+    it('should return the input for a given file handler without exported function', () => {
+      const functionObject = { handler: 'index' };
+      const result = base.calculateFunctionMain(functionObject);
+      expect(result).to.equal(functionObject);
+    });
+    it('should extract the main function for a given path handler', () => {
+      const functionObject = { handler: 'myFunction@0.1.0/index.main' };
+      const result = base.calculateFunctionMain(functionObject);
+      expect(result).to.equal('main');
+    });
+    it('should extract the main function for a given relative path handler', () => {
+      const functionObject = { handler: '../myFunction/index.main' };
+      const result = base.calculateFunctionMain(functionObject);
+      expect(result).to.equal('main');
+    });
+  });
+
+  describe('#convertHandlerToPathInZip()', () => {
+    it('should extract the path in zip for a given file handler', () => {
+      const result = base.convertHandlerToPathInZip('index.main');
+      expect(result).to.equal('index.js');
+    });
+
+    it('should return the input for a given file handler without exported function', () => {
+      const result = base.convertHandlerToPathInZip('index');
+      expect(result).to.equal('index');
+    });
+
+    it('should extract the path in zip for a given path handler', () => {
+      const result = base.convertHandlerToPathInZip('myFunction@0.1.0/index.main');
+      expect(result).to.equal('myFunction@0.1.0/index.js');
+    });
+
+    it('should extract the path in zip for a given relative path handler', () => {
+      const result = base.convertHandlerToPathInZip('../myFunction@0.1.0/index.main');
+      expect(result).to.equal('myFunction@0.1.0/index.js');
+    });
+  });
+
+  describe('#convertHandlerToPath()', () => {
+    it('should extract the path for a given file handler', () => {
+      const result = base.convertHandlerToPath('index.main');
+      expect(result).to.equal('index.js');
+    });
+
+    it('should return the input for a given file handler without exported function', () => {
+      const result = base.convertHandlerToPath('index');
+      expect(result).to.equal('index');
+    });
+
+    it('should extract the path for a given path handler', () => {
+      const result = base.convertHandlerToPath('myFunction@0.1.0/index.main');
+      expect(result).to.equal('myFunction@0.1.0/index.js');
+    });
+
+    it('should extract the path for a given relative path handler', () => {
+      const result = base.convertHandlerToPath('../myFunction@0.1.0/index.main');
+      expect(result).to.equal('../myFunction@0.1.0/index.js');
+    });
+  });
+});

--- a/compile/functions/tests/index.js
+++ b/compile/functions/tests/index.js
@@ -7,29 +7,6 @@ require('chai').use(chaiAsPromised);
 
 const sinon = require('sinon');
 const OpenWhiskCompileFunctions = require('../index');
-const BaseRuntime = require('../runtimes/base.js');
-
-describe('BaseRuntime', () => {
-  describe('#convertHandlerToPath', () => {
-    const base = new BaseRuntime();
-    base.extension = '.js';
-
-    it('should extract the path for a given file handler', () => {
-      const result = base.convertHandlerToPath('index.main');
-      expect(result).to.equal('index.js');
-    });
-
-    it('should return the input for a given file handler without exported function', () => {
-      const result = base.convertHandlerToPath('index');
-      expect(result).to.equal('index');
-    });
-
-    it('should extract the path for a given path handler', () => {
-      const result = base.convertHandlerToPath('myFunction@0.1.0/index.main');
-      expect(result).to.equal('myFunction@0.1.0/index.js');
-    });
-  });
-});
 
 describe('OpenWhiskCompileFunctions', () => {
   let serverless;


### PR DESCRIPTION
* Fixed `calculateFunctionMain()` to support relative paths and paths with dots in it
* Introduced `convertHandlerToPathInZip()` to generate absolute path within action package
* Add unit tests for relative paths
* Fixes #69 