### PR TITLE
Uses only the sub-directory for PHP

### DIFF
--- a/compile/functions/runtimes/php.js
+++ b/compile/functions/runtimes/php.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseRuntime = require('./base')
+const PHP_ACTION_FILE = 'index.php'
 
 class Php extends BaseRuntime {
   constructor (serverless) {
@@ -10,9 +11,19 @@ class Php extends BaseRuntime {
   }
 
   processActionPackage (handlerFile, zip) {
-    return zip.file(handlerFile).async('nodebuffer').then(data => {
-      zip.remove(handlerFile)
-      return zip.file('index.php', data)
+    var fileName = handlerFile, pathSeparatorIndex = handlerFile.lastIndexOf('/');
+    if (pathSeparatorIndex != -1) {
+      zip = zip.folder(handlerFile.substr(0, pathSeparatorIndex));
+      fileName = handlerFile.substr(pathSeparatorIndex + 1);
+    }
+
+    if (fileName == PHP_ACTION_FILE) {
+      return zip;
+    }
+
+    return zip.file(fileName).async('nodebuffer').then(data => {
+      zip.remove(fileName)
+      return zip.file(PHP_ACTION_FILE, data)
     })
   }
 }


### PR DESCRIPTION
As you may already know, the Openwhisk PHP runtime has its few rules:
1. The entrypoint of your function/action should be a file named `index.php` at the root of the ZIP archive
2. If you don't have a `vendor` folder (i.e. some PHP dependencies) at the root of the folder, the runtime will move its own `vendor` folder for whatever reason

The current behaviour of the PHP runtime on this Serverless Framework integration is that the handler file is renamed to the `index.php` file. This works well enough for simple files within the root folder, but will not work for handlers within sub-directories.

This pull-request fixes the scenario of a file-system looking like:
```
- first-function/
+-- composer.json
+-- index.php
+-- vendor/
- 2nd-function/
+-- composer.json
+-- index.php
+-- vendor/
- serverless.yaml
``` 

```yaml
# serverless.yaml
provider:
  name: openwhisk
  runtime: php

package:
  individually: true

functions:
 first-function:
    handler: first-function/index.main
 2nd-function:
    handler: 2nd-function/index.main

plugins:
  - serverless-openwhisk
```