### PR TITLE
Use appropriate class name for docker

### DIFF
--- a/compile/functions/runtimes/docker.js
+++ b/compile/functions/runtimes/docker.js
@@ -1,6 +1,6 @@
 'use strict';
 
-class Sequence {
+class Docker {
   constructor(serverless) {
     this.serverless = serverless
   }
@@ -20,4 +20,4 @@ class Sequence {
 }
 
 
-module.exports = Sequence
+module.exports = Docker


### PR DESCRIPTION
Docker runtime class name is wrongly named as "Sequence". 
It should be "Docker".