### PR TITLE
Adds missing lodash, fixes #90

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "fs-extra": "^1.0.0",
     "get-stdin": "^5.0.1",
     "jszip": "^3.1.3",
+    "lodash": "^4.17.4",
     "moment": "^2.16.0",
     "openwhisk": "^3.4.0"
   },


### PR DESCRIPTION
Lodash required in this line: [...invokeLocal/index.js](https://github.com/serverless/serverless-openwhisk/blob/1d993533bf2f9c2958ecc7033b14d06b72462433/invokeLocal/index.js#L4) but it's not listed in `package.json` deps