### PR TITLE
Support specifying credentials file using WSK_CONFIG_FILE environment variable.

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -11,8 +11,9 @@ user credentials for the OpenWhisk service being used, storing them under
 
 ### User Credentials 
 
-The plugin attempts to parse configuration settings from the `.wskprops` file in the user's home directory. These
-settings can be set manually using the following environment parameters.
+The plugin attempts to parse configuration settings from the `.wskprops` file in the user's home directory,
+or from the file path specified in the `WSK_CONFIG_FILE` environment variable. These  settings can be set
+manually using the following environment parameters.
 
 - **OW_AUTH** - Authentication key for OpenWhisk provider.
 - **OW_APIHOST** - API endpoint for OpenWhisk provider.

--- a/provider/credentials.js
+++ b/provider/credentials.js
@@ -7,7 +7,7 @@ const ENV_PARAMS = ['OW_APIHOST', 'OW_AUTH', 'OW_NAMESPACE', 'OW_APIGW_ACCESS_TO
 
 function getWskPropsFile() {
   const Home = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
-  return path.format({ dir: Home, base: '.wskprops' });
+  return process.env.WSK_CONFIG_FILE || path.format({ dir: Home, base: '.wskprops' });
 }
 
 function readWskPropsFile() {
@@ -48,4 +48,5 @@ module.exports = {
     return getWskProps()
       .then(props => Object.assign(props, getWskEnvProps()));
   },
+  ENV_PARAMS,
 };


### PR DESCRIPTION
This option is described in the [OpenWhisk CLI docs](https://github.com/apache/incubator-openwhisk/blob/master/docs/cli.md#setting-up-the-openwhisk-cli).

Closes #101