### PR TITLE
Allow TypeScript file extension to pass file path runtime check

### DIFF
--- a/compile/functions/runtimes/node.js
+++ b/compile/functions/runtimes/node.js
@@ -17,6 +17,25 @@ class Node extends BaseRuntime {
     zip.file("package.json", JSON.stringify({main: handlerFile}))
     return zip
   }
+
+  //We're handling a special case here which is that if TypeScript is being used
+  //we won't actually have a ".js" file (this.extension), instead we'll have a "ts"
+  //which should still be considered safe enough, or at least shouldn't
+  //completely stop the deployment process
+  isValidFile(handlerFile) {
+    if (fs.existsSync(handlerFile) || this.isValidTypeScriptFile(handlerFile)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  //Check for TypeScript version of handler file
+  isValidTypeScriptFile(handlerFile) {
+    //replaces the last occurance of `.js` with `.ts`, case insensitive
+    const typescriptHandlerFIle = handlerFile.replace(/\.js$/gi, ".ts");
+    return fs.existsSync(typescriptHandlerFIle);
+  }
 }
 
 module.exports = Node

--- a/compile/functions/runtimes/node.js
+++ b/compile/functions/runtimes/node.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const fs = require("fs-extra");
 const BaseRuntime = require('./base')
 
 class Node extends BaseRuntime {
@@ -24,18 +23,14 @@ class Node extends BaseRuntime {
   //which should still be considered safe enough, or at least shouldn't
   //completely stop the deployment process
   isValidFile(handlerFile) {
-    if (fs.existsSync(handlerFile) || this.isValidTypeScriptFile(handlerFile)) {
-      return true;
-    }
-
-    return false;
+    return super.isValidFile(handlerFile) || this.isValidTypeScriptFile(handlerFile);
   }
 
   //Check for TypeScript version of handler file
   isValidTypeScriptFile(handlerFile) {
     //replaces the last occurance of `.js` with `.ts`, case insensitive
-    const typescriptHandlerFIle = handlerFile.replace(/\.js$/gi, ".ts");
-    return fs.existsSync(typescriptHandlerFIle);
+    const typescriptHandlerFile = handlerFile.replace(/\.js$/gi, ".ts");
+    return super.isValidFile(typescriptHandlerFile);
   }
 }
 

--- a/compile/functions/runtimes/node.js
+++ b/compile/functions/runtimes/node.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fs = require("fs-extra");
 const BaseRuntime = require('./base')
 
 class Node extends BaseRuntime {

--- a/compile/functions/runtimes/tests/node.js
+++ b/compile/functions/runtimes/tests/node.js
@@ -7,6 +7,7 @@ require('chai').use(chaiAsPromised);
 
 const sinon = require('sinon');
 const Node = require('../node');
+const BaseRuntime = require('../base');
 const JSZip = require("jszip");
 const fs = require('fs-extra');
 
@@ -94,6 +95,28 @@ describe('Node', () => {
       return expect(node.exec({ handler, image: 'blah', runtime: 'nodejs:6' }))
         .to.eventually.deep.equal(exec);
     })
+  });
+
+  describe('#isValidTypeScriptFile()', () => {
+    it('should report valid file path when a js path is passed that has a ts file instead', () => {
+      //We need to mock the node's `super` call, which is why we're using BaseRuntime
+      sandbox.stub(BaseRuntime.prototype, 'isValidFile', (path) => {
+        expect(path).to.equal('valid_typescript_handler_wrong_extension.ts');
+        return true;
+      });
+      expect(node.isValidTypeScriptFile('valid_typescript_handler_wrong_extension.js')).to.equal(true)
+    });
+  });
+
+  describe('#isValidFile()', () => {
+    it('should still allow a js file to be used for handler', () => {
+      //We need to mock the node's `super` call, which is why we're using BaseRuntime
+      sandbox.stub(BaseRuntime.prototype, 'isValidFile', (path) => {
+        expect(path).to.equal('valid_js_handler.js');
+        return true;
+      });
+      expect(node.isValidFile('valid_js_handler.js')).to.equal(true)
+    });
   });
 
   describe('#generateActionPackage()', () => {


### PR DESCRIPTION
This is related to #109 and "solves" the issue where TypeScript files (which have a `.ts` file extension) will still pass the file exists check for the nodejs runtime.

Out of the box the Base runtime class will check to see if a given source handler exists. This uses the "extension" value for the given runtime (e.g. `this.extension = ".js"` in the case of nodejs. Because this value is hardcoded to a single value, if transpiling TypeScript using the `serverless-plugin-typescript` plugin for example the `isValidFile` check will fail because there will be no handler file with the given path because it is just assumed that the file will end with ".js".

This commit adds a check specifically for a `.ts` file if the check for the `.js` file fails.