### PR TITLE
Add a feed annotation to a trigger when creating a trigger

### DIFF
--- a/deploy/lib/deployTriggers.js
+++ b/deploy/lib/deployTriggers.js
@@ -8,6 +8,12 @@ module.exports = {
       if (this.options.verbose) {
         this.serverless.cli.log(`Deploying Trigger: ${trigger.triggerName}`);
       }
+
+      const feed = this.getFeed(trigger)
+      if (feed) {
+        Object.assign(trigger, { annotations: [{ key: 'feed', value: feed }] });
+      }
+
       return ow.triggers.create(trigger)
        .then(() => {
           if (this.options.verbose) {
@@ -38,5 +44,9 @@ module.exports = {
     const trigger = { feed: undefined };
     return Object.keys(triggers)
       .map(t => Object.assign({}, triggers[t], trigger));
-  }
+  },
+
+  getFeed(trigger) {
+    return trigger.feed;
+  },
 };

--- a/deploy/tests/deployTriggers.js
+++ b/deploy/tests/deployTriggers.js
@@ -32,8 +32,8 @@ describe('deployTriggers', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    const CLI = function () { this.log = function () {};};
-    serverless = {classes: {Error, CLI}, service: {provider: {}, resources: {}, getAllFunctions: () => []}, getProvider: sandbox.spy()};
+    const CLI = function () { this.log = function () {}; };
+    serverless = { classes: { Error, CLI }, service: { provider: {}, resources: {}, getAllFunctions: () => [] }, getProvider: sandbox.spy() };
     const options = {
       stage: 'dev',
       region: 'us-east-1',
@@ -45,7 +45,7 @@ describe('deployTriggers', () => {
       apihost: 'openwhisk.org',
       auth: 'user:pass',
     };
-    openwhiskDeploy.provider = { client: () => {} }
+    openwhiskDeploy.provider = { client: () => {} };
   });
 
   afterEach(() => {
@@ -80,23 +80,21 @@ describe('deployTriggers', () => {
     });
 
     it('should log function deploy information with verbose flag', () => {
-      openwhiskDeploy.options.verbose = true
-      const log = sandbox.stub(openwhiskDeploy.serverless.cli, 'log')
-      const clog = sandbox.stub(openwhiskDeploy.serverless.cli, 'consoleLog')
+      openwhiskDeploy.options.verbose = true;
+      const log = sandbox.stub(openwhiskDeploy.serverless.cli, 'log');
+      const clog = sandbox.stub(openwhiskDeploy.serverless.cli, 'consoleLog');
       sandbox.stub(openwhiskDeploy.provider, 'client', () => {
-        const create = params => {
-          return Promise.resolve();
-        };
+        const create = params => Promise.resolve();
 
         return Promise.resolve({ triggers: { create } });
       });
 
       return openwhiskDeploy.deployTrigger(mockTriggerObject.triggers.myTrigger).then(() => {
-      expect(log.calledTwice).to.be.equal(true);
-      expect(log.args[0][0]).to.be.equal('Deploying Trigger: myTrigger')
-      expect(log.args[1][0]).to.be.equal('Deployed Trigger: myTrigger')
-      })
-    })
+        expect(log.calledTwice).to.be.equal(true);
+        expect(log.args[0][0]).to.be.equal('Deploying Trigger: myTrigger');
+        expect(log.args[1][0]).to.be.equal('Deployed Trigger: myTrigger');
+      });
+    });
 
     it('should deploy trigger with feed annotation to openwhisk', () => {
       sandbox.stub(openwhiskDeploy.provider, 'client', () => {

--- a/deploy/tests/deployTriggers.js
+++ b/deploy/tests/deployTriggers.js
@@ -16,9 +16,16 @@ describe('deployTriggers', () => {
     triggers: {
       myTrigger: {
         triggerName: 'myTrigger',
-        namepspace: 'myNamespace',
+        namespace: 'myNamespace',
         action: 'myAction',
         trigger: 'myTrigger',
+      },
+      feedTrigger: {
+        triggerName: 'myTrigger',
+        namespace: 'myNamespace',
+        action: 'myAction',
+        trigger: 'myTrigger',
+        feed: '/whisk.system/alarms/alarm',
       },
     },
   };
@@ -91,5 +98,17 @@ describe('deployTriggers', () => {
       })
     })
 
+    it('should deploy trigger with feed annotation to openwhisk', () => {
+      sandbox.stub(openwhiskDeploy.provider, 'client', () => {
+        const create = params => {
+          expect(params).to.be.deep.equal(mockTriggerObject.triggers.feedTrigger);
+          return Promise.resolve();
+        };
+
+        return Promise.resolve({ triggers: { create } });
+      });
+      return expect(openwhiskDeploy.deployTrigger(mockTriggerObject.triggers.feedTrigger))
+        .to.eventually.be.fulfilled;
+    });
   });
 });


### PR DESCRIPTION

When wsk CLI create a alarm trigger, generate feed annotation information.
```bash
$ wsk trigger create periodic1 \
  --feed /whisk.system/alarms/alarm \
  --param cron "*/40 * * * *" \
  --param trigger_payload "{\"name\":\"Odin\",\"place\":\"Asgard\"}" \
  -v
```
```bash
REQUEST:
[PUT]	https://lambda-dev.navercorp.com/api/v1/namespaces/keonhee/triggers/periodic1?overwrite=false
Req Headers
{
  "Authorization": [
    "Basic ZTE3ZTAxZGQtNDM1My00MzZkLWJhZTEtMjNkZDVmOTQ1OWZlOk1YUWx0MkdqMW9JMHhDWlBhcXlqM3I0d0xKdzFiSnk2WTh6UTlqRUp1bW1rVzd5YzhHRWxLRjAxQVU4MjJUNlQ="
  ],
  "Content-Type": [
    "application/json"
  ],
  "User-Agent": [
    "OpenWhisk-CLI/1.0 (2018-04-09T03:50:54.484+0000)"
  ]
}
Req Body
{"name":"periodic1","annotations":[{"key":"feed","value":"/whisk.system/alarms/alarm"}]}

RESPONSE:Got response with code 200
Resp Headers
{
  "Access-Control-Allow-Headers": [
    "Authorization, Content-Type"
  ],
  "Access-Control-Allow-Origin": [
    "*"
  ],
  "Connection": [
    "keep-alive"
  ],
  "Content-Length": [
    "172"
  ],
  "Content-Type": [
    "application/json"
  ],
  "Date": [
    "Tue, 24 Apr 2018 08:08:35 GMT"
  ],
  "Server": [
    "nginx/1.11.13"
  ]
}
Response body size is 172 bytes
Response body received:
{"name":"periodic1","publish":false,"annotations":[{"key":"feed","value":"/whisk.system/alarms/alarm"}],"version":"0.0.1","parameters":[],"limits":{},"namespace":"keonhee"}
```
But serverless does not handle anything. There is a problem with the interworking between wsk CLI and serverless.

So feed information must be added in trigger annotation

