### PR TITLE
Fixes 'Unable to read handler file in function' error for Java runtime

### DIFF
--- a/compile/functions/runtimes/java.js
+++ b/compile/functions/runtimes/java.js
@@ -34,13 +34,7 @@ class Java extends BaseRuntime {
   // Ensure zip package used to deploy action has the correct artifacts for the runtime by only
   // including the deployable JAR file.
   processActionPackage(handlerFile, zip) {
-    return zip
-      .file(handlerFile)
-      .async('nodebuffer')
-      .then(data => {
-        const readFile = BbPromise.promisify(fs.readFile);
-        return readFile(handlerFile).then(zipBuffer => JSZip.loadAsync(zipBuffer));
-      });
+    return zip;
   }
 }
 


### PR DESCRIPTION
Fixes #138 

In the base class base.js function `getArtifactZip`, we already read the zipfile into a buffer https://github.com/serverless/serverless-openwhisk/blob/7ffcbef78a52110d1817b32333a4cb4487da9d57/compile/functions/runtimes/base.js#L83 . This is then passed to the subclass' `processActionPackage` function, in this case in java.js https://github.com/serverless/serverless-openwhisk/blob/7ffcbef78a52110d1817b32333a4cb4487da9d57/compile/functions/runtimes/java.js#L36, which thinks the `zip` parameter is a `JSZip` object, thus it all fails with a NPE since `zip.file` does not evaluate.  We just need to`return zip` in the function.

On a cursory review, I think other runtimes may make this mistake as well I think: https://github.com/serverless/serverless-openwhisk/search?q=processActionPackage&unscoped_q=processActionPackage
