### PR TITLE
Fix 'Cannot read property 'packages' of undefined'

### DIFF
--- a/compile/packages/index.js
+++ b/compile/packages/index.js
@@ -24,7 +24,7 @@ class OpenWhiskCompilePackages {
   }
 
   renameManifestPackages() {
-    if (!this.serverless.service.resources.packages) return;
+    if (!this.serverless.service.resources) return;
 
     const manifestPackages = this.serverless.service.resources.packages;
 


### PR DESCRIPTION
After generating a new app with a serverless template, when running `serverless deploy` I get this error:

```shell
  Type Error ---------------------------------------------

  Cannot read property 'packages' of undefined

     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.

  Stack Trace --------------------------------------------

TypeError: Cannot read property 'packages' of undefined
    at OpenWhiskCompilePackages.renameManifestPackages (/Users/dsvrtan/Projects/serverless/my_service/node_modules/serverless-openwhisk/compile/packages/index.js:27:44)
```

I believe this error was introduced with a recent change here: https://github.com/serverless/serverless-openwhisk/commit/6c402c90ba435226e2036176b32c68d70537f04d

After this change the deploy works as expected.