### PR TITLE
Fix specific python version selection

### DIFF
--- a/invokeLocal/invoke.py
+++ b/invokeLocal/invoke.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 import argparse
 import json


### PR DESCRIPTION
This fixes a bug where sls invoke cannot correctly run python3 runtimes, as the python2 binary will be used.

This patch should make serverless use the version specified by the current env (system or virtualenv).