### PR TITLE
Removing package from namespace

### DIFF
--- a/deploy/lib/deployApiGw.js
+++ b/deploy/lib/deployApiGw.js
@@ -34,14 +34,15 @@ module.exports = {
               const swaggerAction = operation['x-openwhisk']
 
               const action = allActions.find(item => item.name === swaggerAction.action)
-              swaggerAction.namespace = action.namespace
-              swaggerAction.url = swaggerAction.url.replace(/web\/_/, `web/${action.namespace}`)
+              const namespace = `${action.namespace}`.replace(/\/.*/, '')
+              swaggerAction.namespace = namespace
+              swaggerAction.url = swaggerAction.url.replace(/web\/_/, `web/${namespace}`)
 
               const id = operation.operationId
               const stmts = swagger["x-ibm-configuration"].assembly.execute[0]['operation-switch'].case
               const stmt = stmts.find(stmt => stmt.operations[0] === id)
               const invoke = stmt.execute[stmt.execute.length -1].invoke
-              invoke['target-url'] = invoke['target-url'].replace(/web\/_/, `web/${action.namespace}`)
+              invoke['target-url'] = invoke['target-url'].replace(/web\/_/, `web/${namespace}`)
             }
           }
         }

--- a/deploy/tests/deployApiGw.js
+++ b/deploy/tests/deployApiGw.js
@@ -72,6 +72,26 @@ describe('deployHttpEvents', () => {
       expect(result).to.be.deep.equal(converted)
     })
 
+    it('should replace default namespace in swagger doc when namespace is with package', async () => {
+      const without_default_ns = fs.readFileSync('./deploy/tests/resources/swagger.json', 'utf-8')
+      const with_default_ns = fs.readFileSync('./deploy/tests/resources/swagger_default_ns.json', 'utf-8')
+      const source = JSON.parse(with_default_ns)
+      const converted = JSON.parse(without_default_ns)
+
+      const actions = [{"name":"hello","namespace":"user@host.com_dev/default"}]
+
+      sandbox.stub(openwhiskDeploy.provider, 'client', () => {
+        const list = params => {
+          return Promise.resolve(actions);
+        };
+
+        return Promise.resolve({ actions: { list } });
+      });
+
+      let result = await openwhiskDeploy.replaceDefaultNamespace(source)
+      expect(result).to.be.deep.equal(converted)
+    })
+
     it('should return same swagger doc including path params', async () => {
       const without_default_ns = fs.readFileSync('./deploy/tests/resources/swagger_ns_paths.json', 'utf-8')
       const with_default_ns = fs.readFileSync('./deploy/tests/resources/swagger_paths.json', 'utf-8')


### PR DESCRIPTION
This PR is because of the [issue 192](https://github.com/serverless/serverless-openwhisk/issues/192).
Basically, I removed the package from the namespace when the function performs the replacement.