### PR TITLE
Fix for "requested resource not found" error on deployment of API's with package name

### DIFF
--- a/deploy/lib/deployApiGw.js
+++ b/deploy/lib/deployApiGw.js
@@ -14,10 +14,10 @@ module.exports = {
             this.serverless.cli.log(`Deployed API Gateway Route: ${JSON.stringify(route)}`);
           }
         }).catch(err => {
-        throw new this.serverless.classes.Error(
-          `Failed to deploy API Gateway route due to error: ${err.message}`
-        );
-      })
+          throw new this.serverless.classes.Error(
+            `Failed to deploy API Gateway route due to error: ${err.message}`
+          );
+        })
     });
   },
 
@@ -27,21 +27,24 @@ module.exports = {
       .then(ow => ow.actions.list())
       .then(allActions => {
 
-        for(let path in swagger.paths) {
-          for(let verb in swagger.paths[path]) {
-            const operation = swagger.paths[path][verb] 
+        for (let path in swagger.paths) {
+          for (let verb in swagger.paths[path]) {
+            const operation = swagger.paths[path][verb]
             if (operation['x-openwhisk'].namespace === '_') {
               const swaggerAction = operation['x-openwhisk']
 
               const action = allActions.find(item => item.name === swaggerAction.action)
-              swaggerAction.namespace = action.namespace
-              swaggerAction.url = swaggerAction.url.replace(/web\/_/, `web/${action.namespace}`)
+
+              const namespace = action.namespace.split("/")[0]
+
+              swaggerAction.namespace = namespace
+              swaggerAction.url = swaggerAction.url.replace(/web\/_/, `web/${namespace}`)
 
               const id = operation.operationId
               const stmts = swagger["x-ibm-configuration"].assembly.execute[0]['operation-switch'].case
               const stmt = stmts.find(stmt => stmt.operations[0] === id)
-              const invoke = stmt.execute[stmt.execute.length -1].invoke
-              invoke['target-url'] = invoke['target-url'].replace(/web\/_/, `web/${action.namespace}`)
+              const invoke = stmt.execute[stmt.execute.length - 1].invoke
+              invoke['target-url'] = invoke['target-url'].replace(/web\/_/, `web/${namespace}`)
             }
           }
         }

--- a/deploy/lib/deployTriggers.js
+++ b/deploy/lib/deployTriggers.js
@@ -25,7 +25,7 @@ module.exports = {
   deployTriggers() {
     const triggers = this.getTriggers(this.serverless.service.triggers);
 
-    if(triggers.length) {
+    if (triggers.length) {
       this.serverless.cli.log('Deploying Triggers...');
     }
 
@@ -35,7 +35,7 @@ module.exports = {
   },
 
   getTriggers(triggers) {
-    const feedMask = { feed: undefined };
+
     return Object.keys(triggers)
       .map(t => {
         const trigger = triggers[t];
@@ -49,7 +49,7 @@ module.exports = {
             },
           });
         }
-        return Object.assign(trigger, feedMask);
+        return trigger;
       });
   },
 };


### PR DESCRIPTION
When functions are deployed with package name. API deployement for that function cause error "requested resource not found".