### PR TITLE
Fix deprecation warning

### DIFF
--- a/configCredentials/index.js
+++ b/configCredentials/index.js
@@ -24,11 +24,14 @@ class OpenWhiskConfigCredentials {
                 usage: 'OpenWhisk platform API hostname.',
                 shortcut: 'h',
                 required: true,
+                type: 'string',
+                
               },
               auth: {
                 usage: 'User authentication credentials for the provider',
                 shortcut: 'a',
                 required: true,
+                type: 'string',
               }
             },
           },


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - OpenWhiskConfigCredentials for "apihost", "auth"
```